### PR TITLE
Rename repository name with opg- prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![eleventy](https://img.shields.io/badge/staticgen-eleventy-%23707070.svg?style=flat-square)](https://11ty.io)
 
-[![repo standards badge](https://img.shields.io/badge/dynamic/json?color=blue&style=for-the-badge&logo=github&label=MoJ%20Compliant&query=%24.result&url=https%3A%2F%2Foperations-engineering-reports.cloud-platform.service.justice.gov.uk%2Fapi%2Fv1%2Fcompliant_public_repositories%2Fperformance-data)](https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/public-github-repositories.html#performance-data "Link to report")
+[![repo standards badge](https://img.shields.io/badge/dynamic/json?color=blue&style=for-the-badge&logo=github&label=MoJ%20Compliant&query=%24.result&url=https%3A%2F%2Foperations-engineering-reports.cloud-platform.service.justice.gov.uk%2Fapi%2Fv1%2Fcompliant_public_repositories%2Fopg-performance-data)](https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/public-github-repositories.html#opg-performance-data "Link to report")
 
 # OPG Services Performance Data
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "performance-data",
+  "name": "opg-performance-data",
   "version": "1.0.0",
   "main": "index.js",
-  "repository": "https://github.com/ministryofjustice/performance-data",
+  "repository": "https://github.com/ministryofjustice/opg-performance-data",
   "author": "John Nolan <john.nolan@digital.justice.gov.uk>",
   "license": "MIT",
   "scripts": {

--- a/src/_data/make_a_lpa/README.md
+++ b/src/_data/make_a_lpa/README.md
@@ -3,5 +3,5 @@
 To query this data run the curl command below or open the [data.json](data.json) file.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ministryofjustice/performance-data/main/src/_data/make_a_lpa/data.json
+curl -fsSL https://raw.githubusercontent.com/ministryofjustice/opg-performance-data/main/src/_data/make_a_lpa/data.json
 ```

--- a/src/_data/use_an_lpa/README.md
+++ b/src/_data/use_an_lpa/README.md
@@ -3,5 +3,5 @@
 To query this data run the curl command below or open the [data.json](data.json) file.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ministryofjustice/performance-data/main/src/_data/use_an_lpa/data.json
+curl -fsSL https://raw.githubusercontent.com/ministryofjustice/opg-performance-data/main/src/_data/use_an_lpa/data.json
 ```


### PR DESCRIPTION
The repository name has now changed to start with `opg-` to match our repo standards.

This PR updates any links in the site referring to the old repository name.