### PR TITLE
attempt at using github api for signed commit

### DIFF
--- a/.github/workflows/monthly_performance_data_pr.yml
+++ b/.github/workflows/monthly_performance_data_pr.yml
@@ -8,7 +8,7 @@ on:
 permissions:
   id-token: write
   contents: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   import-performance-data:
@@ -37,7 +37,7 @@ jobs:
         run: |
           echo "last_month=$(echo $(date -d "last month" +'%y_%m'))" >> $GITHUB_OUTPUT
           export latest_date_in_file=$(date -d $(jq '.[-1]._timestamp' src/_data/${PROJECT}_service/data.json | tr -d '"') '+%y_%m' | awk -F_ '{print $1 "_" $2}')
-          echo "data_path=./src/_data/${PROJECT}_service/data.json" >> $GITHUB_OUTPUT
+          echo "data_path=src/_data/${PROJECT}_service/data.json" >> $GITHUB_OUTPUT
           echo "latest_year_month=$(echo ${latest_date_in_file})" >> $GITHUB_OUTPUT
 
       - name: Download this months performance data files
@@ -64,22 +64,70 @@ jobs:
             echo "skip_pr=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Create Pull Request
+      - name: Create signed commit via GitHub API
         if: steps.combine.outputs.skip_pr == 'false'
         env:
-          GH_TOKEN:  ${{ secrets.ORG_ACCESS_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DATA_FILE: ${{ steps.variables.outputs.data_path }}
-          LAST_MONTH: ${{ steps.variables.outputs.last_month }}
           PROJECT: ${{ matrix.performance.project }}
+          LAST_MONTH: ${{ steps.variables.outputs.last_month }}
         run: |
           branch="$(echo ${PROJECT}-${LAST_MONTH} | tr '_' '-')"
-          git branch $branch
-          git switch $branch
-          echo "**Updated performance data for ${branch}**" >> $GITHUB_STEP_SUMMARY
-          git status -s >> $GITHUB_STEP_SUMMARY
-          git config --global user.email "tools@digital.justice.gov.uk"
-          git config --global user.name "Github Action"
-          git add ${DATA_FILE}
-          git commit -m "Performance data for ${PROJECT}. Year and month: ${LAST_MONTH}"
-          git push --set-upstream origin $branch
-          gh pr create --title "Performance Data for ${PROJECT} ${LAST_MONTH}" --body "Updating Performance Data for ${PROJECT} for year and month ${LAST_MONTH}"
+          git switch -c "$branch"
+          git push --set-upstream origin "$branch"
+          
+          response=$(gh api graphql \
+            -F repository="$GITHUB_REPOSITORY" \
+            -F branch="$branch" \
+            -F headOid="$(git rev-parse HEAD)" \
+            -F message="Performance data for ${PROJECT}. Year and month: ${LAST_MONTH}" \
+            -F path="${DATA_FILE}" \
+            -F content="$(base64 -w0 ${DATA_FILE})" \
+            -f query='
+              mutation(
+                $repository:String!,
+                $branch:String!,
+                $headOid:GitObjectID!,
+                $message:String!,
+                $path:String!,
+                $content:Base64String!
+              ) {
+                createCommitOnBranch(
+                  input:{
+                    branch:{
+                      repositoryNameWithOwner:$repository
+                      branchName:$branch
+                    }
+                    message:{headline:$message}
+                    expectedHeadOid:$headOid
+                    fileChanges:{
+                      additions:[
+                        {
+                          path:$path
+                          contents:$content
+                        }
+                      ]
+                    }
+                  }
+                ) {
+                  commit {
+                    oid
+                    url
+                  }
+                }
+              }
+            '
+          )
+
+          echo "$response"
+          
+          commit_oid=$(echo "$response" | jq -r '.data.createCommitOnBranch.commit.oid')
+          echo "Created commit: $commit_oid"
+          
+          git fetch origin "$branch"
+          
+          gh pr create \
+          --base main \
+          --head "$branch" \
+          --title "Performance Data for ${PROJECT} ${LAST_MONTH}" \
+          --body "Updating Performance Data for ${PROJECT} for year and month ${LAST_MONTH}"


### PR DESCRIPTION
Rather than having to manage gpg keys, decided to use the github graphql api with the github bot that signs the commits!

<img width="804" height="53" alt="image" src="https://github.com/user-attachments/assets/fa564444-6594-40b9-b8d4-8642323e94fd" />

The syntax is a bit of a faff so hopefully this carries on working. As it's just the one file for the PR, I think this is a manageable solution. Tested it can create the signed commit using this method.